### PR TITLE
feat: Implemented multiple actions per repository to allow several apps to be used

### DIFF
--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/Constants.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/Constants.cs
@@ -4,4 +4,7 @@ public static class Constants
 {
     public const string IconPath = "Assets/icon.png";
     public const string WslPrefix = @"\\wsl$\";
+    public const string CodeCommand = "code";
+    public const string ExplorerCommand = "explorer";
+    public const string ExplorerExecutable = "explorer.exe";
 }

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/ExplorerHelper.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/ExplorerHelper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
+
+namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.Helpers;
+
+public static class ExplorerOpener
+{
+    public static bool ShouldOpenInExplorer(Repository repository, CommandSetting command)
+    {
+        // Windows explorer can open both local paths and \\wsl$\... UNC paths.
+        if (IsExplorerCommand(command.WindowsLaunchCommand))
+        {
+            return true;
+        }
+
+        return repository.IsWsl && IsExplorerCommand(command.WslLaunchCommand);
+    }
+
+    public static bool IsExplorerCommand(string launchCommand)
+    {
+        if (string.IsNullOrWhiteSpace(launchCommand))
+        {
+            return false;
+        }
+
+        string executableName = Path.GetFileNameWithoutExtension(launchCommand.Trim().Trim('"'));
+
+        return executableName.Equals(Constants.ExplorerCommand, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static void OpenFolder(Repository repository, PluginInitContext context)
+    {
+        try
+        {
+            _ = Process.Start(
+                new ProcessStartInfo
+                {
+                    FileName = Constants.ExplorerExecutable,
+                    Arguments = repository.Path,
+                    UseShellExecute = true,
+                }
+            );
+        }
+        catch (Exception ex)
+        {
+            context.API.ShowMsg($"Error opening folder {repository.Name}", ex.Message);
+        }
+    }
+}

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/Messages.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/Messages.cs
@@ -41,7 +41,8 @@ public static class Messages
         Result missingLaunchCommandsResult = new()
         {
             Title = "Missing Launch Commands",
-            SubTitle = "Please provide a Windows or WSL launch command in the plugin settings",
+            SubTitle =
+                "Please configure at least one command in the command settings table in plugin settings",
             Score = 100,
             IcoPath = Constants.IconPath,
             Action = (e) =>

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/RepositoryFinder.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/RepositoryFinder.cs
@@ -51,7 +51,14 @@ public class RepositoryFinder
     {
         List<Repository> repositories = new();
 
-        string wslDistributionName = settings.WslDistributionName;
+        CommandSetting? defaultCommand = settings.GetDefaultCommandSetting();
+
+        if (defaultCommand is null)
+        {
+            return repositories;
+        }
+
+        string wslDistributionName = defaultCommand.WslDistributionName;
         string partialWslPath = Constants.WslPrefix + wslDistributionName;
 
         List<string> wslDirectories = settings.WslDirectories;

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/RepositoryOpener.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Helpers/RepositoryOpener.cs
@@ -9,23 +9,29 @@ public static class RepositoryOpener
     public static void OpenFolder(
         Repository repository,
         PluginInitContext context,
-        Settings settings
+        CommandSetting command
     )
     {
+        if (ExplorerOpener.ShouldOpenInExplorer(repository, command))
+        {
+            ExplorerOpener.OpenFolder(repository, context);
+            return;
+        }
+
         if (repository.IsWsl)
         {
-            OpenWslFolder(repository, context, settings);
+            OpenWslFolder(repository, context, command);
         }
         else
         {
-            OpenWindowsFolder(repository, context, settings);
+            OpenWindowsFolder(repository, context, command);
         }
     }
 
     private static void OpenWslFolder(
         Repository repository,
         PluginInitContext context,
-        Settings settings
+        CommandSetting command
     )
     {
         ProcessStartInfo processStartInfo = new()
@@ -36,11 +42,11 @@ public static class RepositoryOpener
         };
 
         processStartInfo.ArgumentList.Add("--distribution");
-        processStartInfo.ArgumentList.Add(settings.WslDistributionName);
+        processStartInfo.ArgumentList.Add(command.WslDistributionName);
 
-        processStartInfo.ArgumentList.Add(settings.WslLaunchCommand);
+        processStartInfo.ArgumentList.Add(command.WslLaunchCommand);
 
-        processStartInfo.ArgumentList.Add($"'{repository.WslPath}'");
+        processStartInfo.ArgumentList.Add(repository.WslPath);
 
         try
         {
@@ -55,12 +61,12 @@ public static class RepositoryOpener
     private static void OpenWindowsFolder(
         Repository repository,
         PluginInitContext context,
-        Settings settings
+        CommandSetting command
     )
     {
         ProcessStartInfo processStartInfo = new()
         {
-            FileName = settings.WindowsLaunchCommand,
+            FileName = command.WindowsLaunchCommand,
             UseShellExecute = true,
             WindowStyle = ProcessWindowStyle.Hidden,
         };

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Main.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Main.cs
@@ -8,7 +8,7 @@ using FuzzyScore.Net;
 
 namespace Flow.Launcher.Plugin.RepositoryQuickLauncher;
 
-public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable
+public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable, IContextMenu
 {
     private PluginInitContext? _context;
     private Settings? _settings;
@@ -18,6 +18,12 @@ public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable
     {
         _context = context;
         _settings = _context.API.LoadSettingJsonStorage<Settings>();
+
+        if (_settings.EnsureDefaultCommandSetting())
+        {
+            _context.API.SaveSettingJsonStorage<Settings>();
+        }
+
         _repositories = RepositoryFinder.FindRepositories(_settings, _context);
     }
 
@@ -33,22 +39,25 @@ public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable
             return Messages.GetMissingDirectoriesMessage(_context);
         }
 
+        CommandSetting? defaultCommand = _settings.GetDefaultCommandSetting();
+
         if (
-            string.IsNullOrWhiteSpace(_settings.WindowsLaunchCommand)
-            || string.IsNullOrWhiteSpace(_settings.WslLaunchCommand)
+            defaultCommand is null
+            || string.IsNullOrWhiteSpace(defaultCommand.WindowsLaunchCommand)
+            || string.IsNullOrWhiteSpace(defaultCommand.WslLaunchCommand)
         )
         {
             return Messages.GetMissingLaunchCommandsMessage(_context);
         }
 
-        return GetResults(query.Search);
+        return GetResults(query.Search, defaultCommand);
     }
 
     public Control CreateSettingPanel()
     {
         SettingsViewModel settingsViewModel = new(_settings ?? new Settings());
 
-        return new SettingsView(_context!, settingsViewModel);
+        return new SettingsView(_context!, settingsViewModel, ReloadData);
     }
 
     public void ReloadData()
@@ -61,7 +70,36 @@ public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable
         Init(_context);
     }
 
-    private List<Result> GetResults(string queryString)
+    public List<Result> LoadContextMenus(Result selectedResult)
+    {
+        if (_context is null || _settings is null)
+        {
+            return new List<Result>();
+        }
+
+        if (selectedResult.ContextData is not Repository repository)
+        {
+            return new List<Result>();
+        }
+
+        return _settings
+            .CommandSettings.Select(commandSetting => new Result
+            {
+                Title = $"Open in {commandSetting.Name}",
+                SubTitle = repository.IsWsl
+                    ? $"{commandSetting.WslDistributionName}: {commandSetting.WslLaunchCommand}"
+                    : commandSetting.WindowsLaunchCommand,
+                IcoPath = Constants.IconPath,
+                Action = _ =>
+                {
+                    RepositoryOpener.OpenFolder(repository, _context, commandSetting);
+                    return true;
+                },
+            })
+            .ToList();
+    }
+
+    private List<Result> GetResults(string queryString, CommandSetting defaultCommand)
     {
         queryString = queryString.ToLowerInvariant().Trim();
 
@@ -94,17 +132,23 @@ public class RepositoryQuickLauncher : IPlugin, ISettingProvider, IReloadable
         }
 
         List<Result> results = scoredRepositories
-            .Select(scoredRepository => new Result()
+            .Select(scoredRepository =>
             {
-                Title = scoredRepository.Repository.GetResultTitle(),
-                SubTitle = scoredRepository.Repository.GetResultSubTitle(),
-                Score = scoredRepository.Score,
-                IcoPath = Constants.IconPath,
-                Action = (e) =>
+                Repository repository = scoredRepository.Repository;
+
+                return new Result()
                 {
-                    RepositoryOpener.OpenFolder(scoredRepository.Repository, _context, _settings);
-                    return true;
-                },
+                    Title = repository.GetResultTitle(),
+                    SubTitle = repository.GetResultSubTitle(),
+                    Score = scoredRepository.Score,
+                    IcoPath = Constants.IconPath,
+                    ContextData = repository,
+                    Action = _ =>
+                    {
+                        RepositoryOpener.OpenFolder(repository, _context, defaultCommand);
+                        return true;
+                    },
+                };
             })
             .ToList();
 

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Models/CommandSetting.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Models/CommandSetting.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Helpers;
+
+namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
+
+public class CommandSetting : IEquatable<CommandSetting>
+{
+    public string Name { get; set; } = "VS Code";
+
+    public string WindowsLaunchCommand { get; set; } = Constants.CodeCommand;
+
+    public string WslDistributionName { get; set; } = "Ubuntu";
+
+    public string WslLaunchCommand { get; set; } = Constants.CodeCommand;
+
+    public bool IsDefault { get; set; }
+
+    public static CommandSetting CreateDefault()
+    {
+        return new CommandSetting
+        {
+            Name = "VS Code",
+            WindowsLaunchCommand = Constants.CodeCommand,
+            WslDistributionName = "Ubuntu",
+            WslLaunchCommand = Constants.CodeCommand,
+            IsDefault = true,
+        };
+    }
+
+    public static CommandSetting CreateExplorer()
+    {
+        return new CommandSetting
+        {
+            Name = "Explorer",
+            WindowsLaunchCommand = Constants.ExplorerCommand,
+            WslDistributionName = "Ubuntu",
+            WslLaunchCommand = Constants.ExplorerExecutable,
+            IsDefault = false,
+        };
+    }
+
+    public static List<CommandSetting> CreateInitialCommandSettings()
+    {
+        return new List<CommandSetting> { CreateDefault(), CreateExplorer() };
+    }
+
+    public bool Equals(CommandSetting? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(Name.Trim(), other.Name.Trim(), StringComparison.Ordinal)
+            && string.Equals(
+                WindowsLaunchCommand.Trim(),
+                other.WindowsLaunchCommand.Trim(),
+                StringComparison.Ordinal
+            )
+            && string.Equals(
+                WslDistributionName.Trim(),
+                other.WslDistributionName.Trim(),
+                StringComparison.Ordinal
+            )
+            && string.Equals(
+                WslLaunchCommand.Trim(),
+                other.WslLaunchCommand.Trim(),
+                StringComparison.Ordinal
+            )
+            && IsDefault == other.IsDefault;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is CommandSetting other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(
+            Name.Trim(),
+            WindowsLaunchCommand.Trim(),
+            WslDistributionName.Trim(),
+            WslLaunchCommand.Trim(),
+            IsDefault
+        );
+    }
+}

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/Models/Settings.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/Models/Settings.cs
@@ -1,13 +1,35 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
 
 public class Settings
 {
-    public string WindowsLaunchCommand { get; set; } = "code";
     public List<string> WindowsDirectories { get; set; } = new List<string>();
 
-    public string WslDistributionName { get; set; } = "Ubuntu";
-    public string WslLaunchCommand { get; set; } = "code";
     public List<string> WslDirectories { get; set; } = new List<string>();
+
+    public List<CommandSetting> CommandSettings { get; set; } =
+        CommandSetting.CreateInitialCommandSettings();
+
+    public CommandSetting? GetDefaultCommandSetting()
+    {
+        return CommandSettings.FirstOrDefault(command => command.IsDefault);
+    }
+
+    public bool EnsureDefaultCommandSetting()
+    {
+        if (CommandSettings.Count > 0)
+        {
+            if (CommandSettings.All(command => !command.IsDefault))
+            {
+                CommandSettings[0].IsDefault = true;
+            }
+
+            return false;
+        }
+
+        CommandSettings.AddRange(CommandSetting.CreateInitialCommandSettings());
+        return true;
+    }
 }

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingRowViewModel.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingRowViewModel.cs
@@ -1,0 +1,86 @@
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
+
+namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.UI;
+
+public class CommandSettingRowViewModel : BaseModel
+{
+    private string _name = string.Empty;
+    private string _windowsLaunchCommand = string.Empty;
+    private string _wslDistributionName = string.Empty;
+    private string _wslLaunchCommand = string.Empty;
+    private bool _isDefault;
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            _name = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string WindowsLaunchCommand
+    {
+        get => _windowsLaunchCommand;
+        set
+        {
+            _windowsLaunchCommand = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string WslDistributionName
+    {
+        get => _wslDistributionName;
+        set
+        {
+            _wslDistributionName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string WslLaunchCommand
+    {
+        get => _wslLaunchCommand;
+        set
+        {
+            _wslLaunchCommand = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsDefault
+    {
+        get => _isDefault;
+        set
+        {
+            _isDefault = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public static CommandSettingRowViewModel FromModel(CommandSetting commandSetting)
+    {
+        return new CommandSettingRowViewModel
+        {
+            Name = commandSetting.Name,
+            WindowsLaunchCommand = commandSetting.WindowsLaunchCommand,
+            WslDistributionName = commandSetting.WslDistributionName,
+            WslLaunchCommand = commandSetting.WslLaunchCommand,
+            IsDefault = commandSetting.IsDefault,
+        };
+    }
+
+    public CommandSetting ToModel()
+    {
+        return new CommandSetting
+        {
+            Name = Name.Trim(),
+            WindowsLaunchCommand = WindowsLaunchCommand.Trim(),
+            WslDistributionName = WslDistributionName.Trim(),
+            WslLaunchCommand = WslLaunchCommand.Trim(),
+            IsDefault = IsDefault,
+        };
+    }
+}

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsView.xaml
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsView.xaml
@@ -1,0 +1,95 @@
+<UserControl
+  x:Class="Flow.Launcher.Plugin.RepositoryQuickLauncher.UI.CommandSettingsView"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:vm="clr-namespace:Flow.Launcher.Plugin.RepositoryQuickLauncher.UI"
+  d:DataContext="{d:DesignInstance Type=vm:CommandSettingsViewModel}"
+  mc:Ignorable="d"
+>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <DataGrid
+      x:Name="CommandSettingsGrid"
+      Grid.Row="0"
+      Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+      AutoGenerateColumns="False"
+      BorderBrush="DarkGray"
+      BorderThickness="1"
+      CanUserAddRows="False"
+      CanUserDeleteRows="False"
+      HeadersVisibility="Column"
+      ItemsSource="{Binding CommandSettings}"
+      SelectionMode="Extended"
+    >
+      <DataGrid.Columns>
+        <DataGridTextColumn
+          Width="*"
+          Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+          Header="Name"
+        />
+        <DataGridTextColumn
+          Width="*"
+          Binding="{Binding WindowsLaunchCommand, UpdateSourceTrigger=PropertyChanged}"
+          Header="Windows Launch Command"
+        />
+        <DataGridTextColumn
+          Width="*"
+          Binding="{Binding WslDistributionName, UpdateSourceTrigger=PropertyChanged}"
+          Header="WSL Distribution Name"
+        />
+        <DataGridTextColumn
+          Width="*"
+          Binding="{Binding WslLaunchCommand, UpdateSourceTrigger=PropertyChanged}"
+          Header="WSL Launch Command"
+        />
+        <DataGridTemplateColumn Width="Auto" Header="Is Default">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate>
+              <CheckBox
+                HorizontalAlignment="Center"
+                Checked="IsDefaultCheckBoxChanged"
+                IsChecked="{Binding IsDefault, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                Unchecked="IsDefaultCheckBoxChanged"
+              />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+
+    <StackPanel
+      Grid.Row="1"
+      Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+      HorizontalAlignment="Right"
+      Orientation="Horizontal"
+    >
+      <Button
+        MinWidth="100"
+        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+        Click="AddButtonClick"
+        Content="Add"
+      />
+      <Button
+        x:Name="DeleteButton"
+        MinWidth="100"
+        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+        Click="DeleteButtonClick"
+        Content="Delete"
+        IsEnabled="{Binding CanDelete}"
+      />
+      <Button
+        MinWidth="100"
+        Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+        Click="SaveButtonClick"
+        Content="Save"
+        IsEnabled="{Binding CanSave}"
+      />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsView.xaml.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsView.xaml.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
+
+namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.UI;
+
+public partial class CommandSettingsView : UserControl
+{
+    private readonly PluginInitContext _context;
+    private readonly CommandSettingsViewModel _viewModel;
+    private readonly Action _onSaved;
+
+    public CommandSettingsView(
+        PluginInitContext context,
+        CommandSettingsViewModel viewModel,
+        Action onSaved
+    )
+    {
+        _context = context;
+        _viewModel = viewModel;
+        _onSaved = onSaved;
+
+        DataContext = viewModel;
+
+        InitializeComponent();
+    }
+
+    private void AddButtonClick(object sender, RoutedEventArgs e)
+    {
+        _viewModel.AddRow();
+    }
+
+    private void DeleteButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (!_viewModel.CanDelete)
+        {
+            return;
+        }
+
+        _ = _viewModel.TryDeleteSelected(
+            CommandSettingsGrid.SelectedItems.Cast<CommandSettingRowViewModel>()
+        );
+    }
+
+    private void SaveButtonClick(object sender, RoutedEventArgs e)
+    {
+        string? validationError = _viewModel.Validate();
+
+        if (validationError is not null)
+        {
+            _context.API.ShowMsg("Invalid command settings", validationError);
+            return;
+        }
+
+        _viewModel.SyncToSettings();
+        _context.API.SaveSettingJsonStorage<Settings>();
+        _onSaved();
+    }
+
+    private void IsDefaultCheckBoxChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is not CheckBox checkBox)
+        {
+            return;
+        }
+
+        if (checkBox.DataContext is not CommandSettingRowViewModel row || !row.IsDefault)
+        {
+            return;
+        }
+
+        _viewModel.SetDefault(row);
+    }
+}

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsViewModel.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/CommandSettingsViewModel.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Helpers;
+using Flow.Launcher.Plugin.RepositoryQuickLauncher.Models;
+
+namespace Flow.Launcher.Plugin.RepositoryQuickLauncher.UI;
+
+public class CommandSettingsViewModel : BaseModel
+{
+    public Settings Settings { get; }
+
+    public ObservableCollection<CommandSettingRowViewModel> CommandSettings { get; }
+
+    public bool CanDelete => CommandSettings.Count > 1;
+
+    public bool CanSave => HasUnsavedChanges();
+
+    public CommandSettingsViewModel(Settings settings)
+    {
+        Settings = settings;
+        CommandSettings = new ObservableCollection<CommandSettingRowViewModel>(
+            settings.CommandSettings.Select(CommandSettingRowViewModel.FromModel)
+        );
+
+        foreach (CommandSettingRowViewModel row in CommandSettings)
+        {
+            SubscribeToRow(row);
+        }
+
+        CommandSettings.CollectionChanged += OnCommandSettingsCollectionChanged;
+    }
+
+    private void OnCommandSettingsCollectionChanged(
+        object? sender,
+        NotifyCollectionChangedEventArgs e
+    )
+    {
+        OnPropertyChanged(nameof(CanDelete));
+        OnPropertyChanged(nameof(CanSave));
+
+        if (e.NewItems is not null)
+        {
+            foreach (CommandSettingRowViewModel row in e.NewItems)
+            {
+                SubscribeToRow(row);
+            }
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (CommandSettingRowViewModel row in e.OldItems)
+            {
+                UnsubscribeFromRow(row);
+            }
+        }
+    }
+
+    private void SubscribeToRow(CommandSettingRowViewModel row)
+    {
+        row.PropertyChanged += OnRowPropertyChanged;
+    }
+
+    private void UnsubscribeFromRow(CommandSettingRowViewModel row)
+    {
+        row.PropertyChanged -= OnRowPropertyChanged;
+    }
+
+    private void OnRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(CanSave));
+    }
+
+    public void AddRow()
+    {
+        CommandSettings.Add(
+            new CommandSettingRowViewModel
+            {
+                Name = "New Command",
+                WindowsLaunchCommand = Constants.CodeCommand,
+                WslDistributionName = "Ubuntu",
+                WslLaunchCommand = Constants.CodeCommand,
+                IsDefault = CommandSettings.Count == 0,
+            }
+        );
+    }
+
+    public bool TryDeleteSelected(IEnumerable<CommandSettingRowViewModel> selectedRows)
+    {
+        if (CommandSettings.Count <= 1)
+        {
+            return false;
+        }
+
+        List<CommandSettingRowViewModel> rowsToDelete = selectedRows.ToList();
+
+        if (rowsToDelete.Count == 0)
+        {
+            return false;
+        }
+
+        if (CommandSettings.Count - rowsToDelete.Count < 1)
+        {
+            return false;
+        }
+
+        bool deletedDefault = rowsToDelete.Any(row => row.IsDefault);
+
+        foreach (CommandSettingRowViewModel row in rowsToDelete)
+        {
+            _ = CommandSettings.Remove(row);
+        }
+
+        if (deletedDefault && CommandSettings.Count > 0)
+        {
+            SetDefault(CommandSettings[0]);
+        }
+
+        return true;
+    }
+
+    public void SetDefault(CommandSettingRowViewModel selectedRow)
+    {
+        foreach (CommandSettingRowViewModel row in CommandSettings)
+        {
+            row.IsDefault = ReferenceEquals(row, selectedRow);
+        }
+    }
+
+    public string? Validate()
+    {
+        if (CommandSettings.Count == 0)
+        {
+            return "At least one command setting is required.";
+        }
+
+        int defaultCount = CommandSettings.Count(row => row.IsDefault);
+
+        if (defaultCount != 1)
+        {
+            return "Exactly one command setting must be marked as default.";
+        }
+
+        foreach (CommandSettingRowViewModel row in CommandSettings)
+        {
+            if (string.IsNullOrWhiteSpace(row.Name))
+            {
+                return "Each command setting must have a name.";
+            }
+
+            if (string.IsNullOrWhiteSpace(row.WindowsLaunchCommand))
+            {
+                return $"Windows launch command is required for \"{row.Name}\".";
+            }
+
+            if (string.IsNullOrWhiteSpace(row.WslDistributionName))
+            {
+                return $"WSL distribution name is required for \"{row.Name}\".";
+            }
+
+            if (string.IsNullOrWhiteSpace(row.WslLaunchCommand))
+            {
+                return $"WSL launch command is required for \"{row.Name}\".";
+            }
+        }
+
+        return null;
+    }
+
+    public void SyncToSettings()
+    {
+        Settings.CommandSettings = CommandSettings.Select(row => row.ToModel()).ToList();
+        OnPropertyChanged(nameof(CanSave));
+    }
+
+    private bool HasUnsavedChanges()
+    {
+        return !CommandSettings
+            .Select(row => row.ToModel())
+            .SequenceEqual(Settings.CommandSettings);
+    }
+}

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsView.xaml
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsView.xaml
@@ -20,69 +20,7 @@
       <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
 
-    <Grid Grid.Row="0">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-      </Grid.RowDefinitions>
-
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="Auto" SharedSizeGroup="A" />
-        <ColumnDefinition Width="*" SharedSizeGroup="B" />
-      </Grid.ColumnDefinitions>
-
-      <TextBlock
-        Grid.Row="0"
-        Grid.Column="0"
-        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-        VerticalAlignment="Center"
-        Foreground="{DynamicResource Color05B}"
-        Text="Windows Launch Command"
-      />
-
-      <TextBox
-        Grid.Row="0"
-        Grid.Column="1"
-        Margin="{StaticResource SettingPanelItemTopBottomMargin}"
-        VerticalAlignment="Center"
-        Text="{Binding WindowsLaunchCommand}"
-      />
-
-      <TextBlock
-        Grid.Row="1"
-        Grid.Column="0"
-        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-        VerticalAlignment="Center"
-        Foreground="{DynamicResource Color05B}"
-        Text="WSL Distribution Name"
-      />
-
-      <TextBox
-        Grid.Row="1"
-        Grid.Column="1"
-        Margin="{StaticResource SettingPanelItemTopBottomMargin}"
-        VerticalAlignment="Center"
-        Text="{Binding WslDistributionName}"
-      />
-
-      <TextBlock
-        Grid.Row="2"
-        Grid.Column="0"
-        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-        VerticalAlignment="Center"
-        Foreground="{DynamicResource Color05B}"
-        Text="WSL Launch Command"
-      />
-
-      <TextBox
-        Grid.Row="2"
-        Grid.Column="1"
-        Margin="{StaticResource SettingPanelItemTopBottomMargin}"
-        VerticalAlignment="Center"
-        Text="{Binding WslLaunchCommand}"
-      />
-    </Grid>
+    <ContentControl x:Name="CommandSettingsPanelHost" Grid.Row="0" />
 
     <Separator Grid.Row="1" Style="{StaticResource SettingPanelSeparatorStyle}" />
 

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsView.xaml.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsView.xaml.cs
@@ -10,21 +10,30 @@ public partial class SettingsView : UserControl
 {
     private readonly PluginInitContext _context;
     private readonly SettingsViewModel _viewModel;
+    private readonly Action _onSaved;
 
-    public SettingsView(PluginInitContext context, SettingsViewModel viewModel)
+    public SettingsView(PluginInitContext context, SettingsViewModel viewModel, Action onSaved)
     {
         _context = context;
         _viewModel = viewModel;
+        _onSaved = onSaved;
 
         DataContext = viewModel;
 
         InitializeComponent();
+
+        CommandSettingsPanelHost.Content = new CommandSettingsView(
+            context,
+            viewModel.CommandSettingsViewModel,
+            onSaved
+        );
     }
 
     private void Save()
     {
         _viewModel.SyncDirectoriesToSettings();
         _context.API.SaveSettingJsonStorage<Settings>();
+        _onSaved();
     }
 
     private void WindowsDirectoriesButtonAddClick(object sender, RoutedEventArgs e)

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsViewModel.cs
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/UI/SettingsViewModel.cs
@@ -8,39 +8,11 @@ public class SettingsViewModel : BaseModel
 {
     public Settings Settings { get; }
 
-    public string WindowsLaunchCommand
-    {
-        get => Settings.WindowsLaunchCommand;
-        set
-        {
-            Settings.WindowsLaunchCommand = value;
-            OnPropertyChanged();
-        }
-    }
-
     public ObservableCollection<string> WindowsDirectoriesCollection { get; }
 
-    public string WslDistributionName
-    {
-        get => Settings.WslDistributionName;
-        set
-        {
-            Settings.WslDistributionName = value;
-            OnPropertyChanged();
-        }
-    }
-
-    public string WslLaunchCommand
-    {
-        get => Settings.WslLaunchCommand;
-        set
-        {
-            Settings.WslLaunchCommand = value;
-            OnPropertyChanged();
-        }
-    }
-
     public ObservableCollection<string> WslDirectoriesCollection { get; }
+
+    public CommandSettingsViewModel CommandSettingsViewModel { get; }
 
     public SettingsViewModel(Settings settings)
     {
@@ -49,6 +21,7 @@ public class SettingsViewModel : BaseModel
             Settings.WindowsDirectories
         );
         WslDirectoriesCollection = new ObservableCollection<string>(Settings.WslDirectories);
+        CommandSettingsViewModel = new CommandSettingsViewModel(Settings);
     }
 
     public void SyncDirectoriesToSettings()

--- a/Flow.Launcher.Plugin.RepositoryQuickLauncher/plugin.json
+++ b/Flow.Launcher.Plugin.RepositoryQuickLauncher/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Repository Quick Launcher",
   "Description": "A Flow Launcher plugin to quickly open codebases using your IDE of choice (VS Code, Cursor, Zed, etc.)",
   "Author": "RudraPatel2003",
-  "Version": "1.0.1",
+  "Version": "1.1.0",
   "Language": "csharp",
   "Website": "https://github.com/RudraPatel2003/repository-quick-launcher",
   "IcoPath": "Assets/icon.png",


### PR DESCRIPTION
# Multi-action command settings

## Back story

This change lets you configure multiple named launch profiles and pick the right one per repository. Flow Launcher’s **Shift+Enter** submenu is used to choose among them; **Enter** still runs your default action. Explorer and VS Code is included out of the box so you can open a repo in File Explorer without a separate workflow.

## Summary

- **Multiple launch profiles** — Replaced flat `WindowsLaunchCommand` / WSL settings with a `CommandSettings` list. Each row has a display name, Windows command, WSL distro, WSL command, and a default flag.
- **Command settings UI** — Added `CommandSettingsView` (DataGrid + Add / Delete / Save). Edits are saved only when you press Save; the plugin reloads settings in memory automatically after a successful save.
- **Shift+Enter submenu** — Implemented `IContextMenu` so each configured profile appears as “Open in {Name}” when you hold Shift and press Enter on a repository result.
- **Default action on Enter** — Pressing Enter opens the repository with the profile marked as default.
- **Windows Explorer support** — Added `ExplorerOpener` to detect explorer-based commands and open folders via `explorer.exe` (works for local paths and `\\wsl$\...` UNC paths). Fresh installs seed VS Code (default) and Explorer presets.
- **Per-command execution** — `RepositoryOpener` and `RepositoryFinder` now use the selected `CommandSetting` instead of global launch fields.

<img width="758" height="456" alt="screen" src="https://github.com/user-attachments/assets/7af066c6-a561-4a51-8678-31b4c0d20e9f" />
